### PR TITLE
This was annoying to figure out.

### DIFF
--- a/src/main/java/com/example/softwareengineering/controller/RegistrationRouteController.java
+++ b/src/main/java/com/example/softwareengineering/controller/RegistrationRouteController.java
@@ -17,6 +17,7 @@ public class RegistrationRouteController {
         this.repo = repo;
     }
 
+    @CrossOrigin(origins = "*")
     @RequestMapping(value = "/register", method = RequestMethod.POST)
     @ResponseBody
     public ResponseEntity CreateEmployee(@RequestBody int employeeId, @RequestBody String password, @RequestBody String firstName, @RequestBody String lastName, @RequestBody String role, @RequestBody int managerId) {


### PR DESCRIPTION
{
    "employeeID": 2,
    "firstName": "John",
    "lastName": "Johnson",
    "password": "wowee",
    "active": "true",
    "role": "",
    "managerID": 1
}
Has to be formatted like this or it won't work.
And if someone is a shift manager replace General Manager with Shift Manager