### PR TITLE
Swapped register IDs to generation

### DIFF
--- a/src/main/java/com/example/softwareengineering/controller/RegistrationRouteController.java
+++ b/src/main/java/com/example/softwareengineering/controller/RegistrationRouteController.java
@@ -20,10 +20,10 @@ public class RegistrationRouteController {
     @CrossOrigin(origins = "*")
     @RequestMapping(value = "/register", method = RequestMethod.POST)
     @ResponseBody
-    public ResponseEntity CreateEmployee(@RequestBody Employee emp) {
+    public ResponseEntity<Integer> CreateEmployee(@RequestBody Employee emp) {
         try {
             repo.save(emp);
-            return new ResponseEntity(HttpStatus.OK);
+            return new ResponseEntity(emp.getEmployeeID(), HttpStatus.OK);
         } catch (Exception e) {
             return new ResponseEntity(HttpStatus.BAD_REQUEST);
         }

--- a/src/main/java/com/example/softwareengineering/entity/Employee.java
+++ b/src/main/java/com/example/softwareengineering/entity/Employee.java
@@ -1,5 +1,6 @@
 package com.example.softwareengineering.entity;
 
+import com.example.softwareengineering.repository.EmployeeRepository;
 import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.*;
@@ -28,8 +29,8 @@ public class Employee {
         this.ManagerID = managerID;
     }
 
-    public Employee(Integer employeeID, String lastName, String firstname, String password, String role, Integer managerID) {
-        this.EmployeeID = employeeID;
+    public Employee(String lastName, String firstname, String password, String role, Integer managerID) {
+        this.EmployeeID = (int)(Math.random()*89999)+10000;
         this.FirstName = firstname;
         this.LastName = lastName;
         this.password = password;


### PR DESCRIPTION
Employee IDs are no longer passed in as part of the registration process, they're now randomly generated 5-digit numbers passed back as part of the response body